### PR TITLE
Project abandoned in favor of markdown-clj

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,61 @@
-# reactive-markdown (WORK IN PROGRESS)
+# reactive-markdown (abandoned)
 
-This tiny library renders Markdown strings to React components.
+This project is only useful for explaining how to create a Markdown to raw html
+component for React. It used to be a library, but it eventually is not
+necessary, now that I have discovered
+[```markdown-clj```](https://github.com/yogthos/markdown-clj).
 
-The code is borrowed from Bruce Hauman's amazing
-[devcards](https://github.com/bhauman/devcards) with his blessing.
+Therefore, after importing the correct dependencies (js/React should be
+visible) you will be able to do:
 
-The employed Markdown->HTML converter in both this library and ```devcards```
-is [showdownjs](https://github.com/showdownjs/showdown).
+ ``` clojure
 
-There are is one function only in the ```reactive-markdown.markdown```
-namespace that you can use: ```md->react```. It is a variadic function that
-accepts strings and returns a React component. Easy peasy.
+(ns reactive-markdown.demo
+  (:require [reagent.core :as reagent]
+            [markdown.core :as mclj :refer [md->html]]))
 
-``` clojure
+(def state (reagent/atom {:bold false
+                          :italic false}))
 
-(defn blog-post []
-  (markdown/md->react
-   "## Why would you want that?
+;; from bhauman/devcards
+(defn react-raw [raw-html-str]
+  "A React component that renders raw html."
+  (.div (.-DOM js/React)
+        (clj->js { :key (str (hash raw-html-str))
+                  :dangerouslySetInnerHTML
+                  { :__html
+                   raw-html-str}})))
 
-    Easy, in order to **write** a _blog post_ using:
+(defn blog-post
+  []
+  (react-raw
+   (mclj/md->html
+    (str "## Using `markdown-clj`\n"
+         "Easy, in order to "
+         (if (:bold @state) "**write**" "write")
+         " an interactive "
+         (if (:italic @state) "_blog post_" "blog post")
+         " using:\n\n"
+         "* [Reagent](https://github.com/reagent-project/reagent)\n"
+         "* [Markdown](https://daringfireball.net/projects/markdown/)"))))
 
-    1. Reagent
-    2. Markdown"))
-    
 ```
 
-For further details, if you really need them, have a look at the ```demo-src```
-folder.
+See ```demo.cljs``` for details (the old code is left there as comparison.  I
+am willing to deploy this library if there is a need, but I don't see any at
+the moment.
 
-## Development Mode
+---
 
-```lein fig-demo``` (will clean it for you)  **or** ```lein figwheel demo```
+<del>This tiny library renders Markdown strings to React components.
 
-Figwheel will automatically push cljs changes to the browser.
+<del>The code is borrowed from Bruce Hauman's amazing
+[devcards](https://github.com/bhauman/devcards) with his blessing.</del>
 
-Wait a bit, then browse to [http://localhost:3449](http://localhost:3449).
+<del>The employed Markdown->HTML converter in both this library and ```devcards```
+is [showdownjs](https://github.com/showdownjs/showdown).</del>
 
-## Production Build
+<del>There are is one function only in the ```reactive-markdown.markdown```
+namespace that you can use: ```md->react```. It is a variadic function that
+accepts strings and returns a React component. Easy peasy.</del>
 
-```lein minify``` **or** ```lein do clean, cljsbuild once min```
-
-## Testing
-
-For testing, you need first of all [PhantomJS](https://github.com/ariya/phantomjs/), after which you can execute:
-
-```lein unit-test``` **or** ```lein do clean, cljsbuild test unit```
-
-## Other Resources
-
- * [CLJSJS](https://github.com/cljsjs/packages)

--- a/demo-src/cljs/reactive_markdown/demo.cljs
+++ b/demo-src/cljs/reactive_markdown/demo.cljs
@@ -1,18 +1,64 @@
 (ns reactive-markdown.demo
   (:require [reagent.core :as reagent]
-            [reactive-markdown.markdown :as markdown]))
+            [markdown.core :as mclj :refer [md->html]]
+            [reactive-markdown.markdown :as mine :refer [md->react]]))
 
 (enable-console-print!)
 
-(defn blog-post []
-  (markdown/md->react
-   "## Why would you want that?
+(def state (reagent/atom {:bold false
+                          :italic false}))
 
-    Easy, in order to **write** a _blog post_ using:
+;; from bhauman/devcards
+(defn react-raw [raw-html-str]
+  "A React component that renders raw html."
+  (.div (.-DOM js/React)
+        (clj->js { :key (str (hash raw-html-str))
+                  :dangerouslySetInnerHTML
+                  { :__html
+                   raw-html-str}})))
 
-    1. [Reagent](https://github.com/reagent-project/reagent)
-    2. [Markdown](https://daringfireball.net/projects/markdown/)"))
+(defn blog-post
+  []
+  (react-raw
+   (mclj/md->html
+    (str "## Using `markdown-clj`\n"
+         "Easy, in order to "
+         (if (:bold @state) "**write**" "write")
+         " an interactive "
+         (if (:italic @state) "_blog post_" "blog post")
+         " using:\n\n"
+         "* [Reagent](https://github.com/reagent-project/reagent)\n"
+         "* [Markdown](https://daringfireball.net/projects/markdown/)"))))
+
+(defn blog-post2 []
+  (mine/md->react (str "## Using `devcards`\n"
+                  "Easy, in order to "
+                  (if (:bold @state) "**write**" "write")
+                  " a "
+                  (if (:italic @state) "_blog post_" "blog post")
+                  " using:\n\n"
+                  "* [Reagent](https://github.com/reagent-project/reagent)\n"
+                  "* [Markdown](https://daringfireball.net/projects/markdown/)")))
+
+(defn toggle-bold [] (swap! state update-in [:bold] not))
+(defn toggle-italic [] (swap! state update-in [:italic] not))
+
+(defn console []
+  (fn [{:keys [bold italic]}]
+    [:div.view
+     [:input.toggle {:type "checkbox" :checked bold
+                     :on-change #(toggle-bold)}]
+     [:label (if (:bold @state) "Bold on" "Bold off")]
+     [:input.toggle {:type "checkbox" :checked italic
+                     :on-change #(toggle-italic)}]
+     [:label (if (:italic @state) "Italic on" "Italic off")]]))
+
+(defn page
+  []
+  [:div.page [blog-post]
+             [blog-post2]
+             [console]])
 
 (defn ^:export main []
-  (reagent/render [blog-post]
+  (reagent/render [page]
                   (.getElementById js/document "demo-app")))

--- a/project.clj
+++ b/project.clj
@@ -2,6 +2,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.122"]
                  [reagent "0.5.1"]
+                 [markdown-clj "0.9.75"]
                  [cljsjs/showdown "0.4.0-1"]]
   :plugins [[lein-cljsbuild "1.1.0"]
             [lein-figwheel "0.4.1" :exclusions [cider/cider-nrepl]]  ]


### PR DESCRIPTION
The project has been abandoned because I discovered of the existence of `markdown-clj`.

The README has been changes in order to show how to create a raw React component (code again taken from `bhauman/devcards`.
